### PR TITLE
Whitelist electrs

### DIFF
--- a/logic/disk.js
+++ b/logic/disk.js
@@ -166,8 +166,8 @@ function settingsToMultilineConfString(settings) {
   umbrelBitcoinConfig.push(`bind=0.0.0.0:8333`);
   umbrelBitcoinConfig.push(`bind=${constants.BITCOIND_IP}:8334=onion`);
 
-  umbrelBitcoinConfig.push(`# Whitelist electrs`);
-  umbrelBitcoinConfig.push(`whitelist=10.21.21.10`);
+  umbrelBitcoinConfig.push(`# Whitelist local range`);
+  umbrelBitcoinConfig.push(`whitelist=10.21.0.0/16`);
 
   return umbrelBitcoinConfig.join('\n');
 }

--- a/logic/disk.js
+++ b/logic/disk.js
@@ -166,6 +166,9 @@ function settingsToMultilineConfString(settings) {
   umbrelBitcoinConfig.push(`bind=0.0.0.0:8333`);
   umbrelBitcoinConfig.push(`bind=${constants.BITCOIND_IP}:8334=onion`);
 
+  umbrelBitcoinConfig.push(`# Whitelist electrs`);
+  umbrelBitcoinConfig.push(`whitelist=10.21.21.10`);
+
   return umbrelBitcoinConfig.join('\n');
 }
 


### PR DESCRIPTION
Newer versions of Electrs use the P2P protocol instead of the RPC protocol to connect to the local Bitcoin node. But currently the IP of electrs is not whitelisted. 

Two of the benefits of doing so are:

- If there are no free slots for incoming connections (because `maxconnections` has been reached) it will still allow electrs to connect because it will drop an existing peer to make room.
- If the `maxuploadtarget` is reached it will allow electrs to continue downloading blocks for indexing as the limit is not applied to whitelisted peers.