### PR TITLE
Add current block height to "Sync" widget

### DIFF
--- a/logic/widgets.js
+++ b/logic/widgets.js
@@ -61,7 +61,7 @@ async function getBitcoinSyncWidgetData() {
     refresh: '2s',
     link: '',
     title: 'Blockchain sync',
-    text: `${syncPercent}%`,
+    text: `Block Height: ${sync.currentBlock}, ${syncPercent}%`,
     progressLabel: syncPercent === 100 ? 'Synced' : 'In progress',
     progress: syncPercent / 100
   };

--- a/logic/widgets.js
+++ b/logic/widgets.js
@@ -61,7 +61,7 @@ async function getBitcoinSyncWidgetData() {
     refresh: '2s',
     link: '',
     title: 'Blockchain sync',
-    text: `Block Height: ${sync.currentBlock}, ${syncPercent}%`,
+    text: `${sync.currentBlock}, ${syncPercent}%`,
     progressLabel: syncPercent === 100 ? 'Synced' : 'In progress',
     progress: syncPercent / 100
   };


### PR DESCRIPTION
**Problem**:  Block Height is a universal important number to Bitcoin and there are no widgets in all of Umbrel (to my knowledge) that show the "Block Height" in a widget.

**Solution**: Show the Block Height in the sync widget.  This works well because 1) it gives users a quick glance at their block height if they are syncing and 2) it gives users the current block height which is usually fairly "universal".

<img width="301" alt="Screenshot 2024-12-03 at 9 14 49 AM" src="https://github.com/user-attachments/assets/4f78f9b2-2e9d-4960-9593-96c1a6e843f7">

**Discussion**:  I originally had "Block Height: xxxxxx, 100%" but it took up too much space so I just reduced it to "xxxxxx, 100%" which personally I prefer anyways.

Thank you very much for consideration.