### PR TITLE
feat: Restrict datacarriersize to 0, 42, or 83 bytes

### DIFF
--- a/apps/backend/src/modules/config/config.ts
+++ b/apps/backend/src/modules/config/config.ts
@@ -41,6 +41,9 @@ function applyDerivedSettings(settings: SettingsSchema): SettingsSchema {
 	// If prune > 0 -> txindex must be off
 	if (newSettings['prune'] > 0) newSettings['txindex'] = false
 
+	// If datacarrier is off -> datacarriersize must be 0
+	if (!newSettings['datacarrier']) newSettings['datacarriersize'] = 0
+
 	// If proxy is on, but onlynet doesn't include clearnet and tor -> disable proxy
 	if (
 		newSettings['proxy'] &&

--- a/libs/settings/settings.meta.ts
+++ b/libs/settings/settings.meta.ts
@@ -23,6 +23,8 @@ interface NumberOption extends BaseOption {
 	step?: number
 	default: number
 	unit?: string
+	disabledWhen?: Record<string, (v: unknown) => boolean>
+	disabledMessage?: string
 }
 
 interface BooleanOption extends BaseOption {
@@ -304,9 +306,13 @@ export const settingsMetadata = {
 		kind: 'number',
 		label: 'Max Allowed Size of Arbitrary Data in Transactions',
 		bitcoinLabel: 'datacarriersize',
-		description: 'Set the maximum size of the data in OP_RETURN outputs (in bytes) that your node will relay.',
-		subDescription: 'Note: datacarrier must be enabled for this setting to take effect.',
+		description: 'Set the maximum size of the data in OP_RETURN outputs (in bytes) that your node will relay. Only values 0, 42, or 83 bytes are allowed.',
+		subDescription: '⚠ This setting is automatically set to 0 when datacarrier is disabled.',
 		default: 83,
+		disabledWhen: {
+			datacarrier: (v: unknown) => v === false,
+		},
+		disabledMessage: 'automatically set to 0 when datacarrier is disabled',
 	},
 
 	permitbaremultisig: {

--- a/libs/settings/settings.schema.ts
+++ b/libs/settings/settings.schema.ts
@@ -56,5 +56,15 @@ for (const key of Object.keys(settingsMetadata) as Array<keyof typeof settingsMe
 	}
 }
 
+// Custom validation: restrict datacarriersize to only 0, 42, or 83 bytes
+if (schemaMap.datacarriersize) {
+	schemaMap.datacarriersize = (schemaMap.datacarriersize as z.ZodNumber).refine(
+		(val: number) => val === 0 || val === 42 || val === 83,
+		{
+			message: 'datacarriersize must be 0, 42, or 83 bytes',
+		}
+	)
+}
+
 export const settingsSchema = z.object(schemaMap as Record<string, z.ZodTypeAny>)
 export type SettingsSchema = z.infer<typeof settingsSchema>


### PR DESCRIPTION
- Add custom Zod validation to only allow 0, 42, or 83 bytes
- Link datacarriersize to datacarrier toggle (auto-set to 0 when disabled)
- Add disabledWhen support to NumberOption interface
- Update UI descriptions to reflect restrictions