### PR TITLE
Make default dbcache RAM-aware, matching Bitcoin Core v31

### DIFF
--- a/apps/backend/src/modules/config/config.ts
+++ b/apps/backend/src/modules/config/config.ts
@@ -1,5 +1,6 @@
 // TODO: break out some config-helpers into a separate file
 
+import os from 'node:os'
 import path from 'node:path'
 import {createHmac, randomBytes} from 'node:crypto'
 import fse from 'fs-extra'
@@ -37,7 +38,7 @@ let cachedSettings: SettingsSchema | undefined
 function mergeWithDefaults(partial: Partial<SettingsSchema>): SettingsSchema {
 	const selectedVersion = ((partial as {version?: SelectedVersion})?.version ?? LATEST) as SelectedVersion
 	const resolvedVersion = resolveVersion(selectedVersion)
-	const defaults = DefaultValuesForVersion(resolvedVersion) as Record<string, unknown>
+	const defaults = DefaultValuesForVersion(resolvedVersion, {totalRamBytes: os.totalmem()}) as Record<string, unknown>
 	return {...defaults, ...partial} as SettingsSchema
 }
 
@@ -370,6 +371,11 @@ export async function getSettings(): Promise<SettingsSchema> {
 	return cachedSettings
 }
 
+// System information the UI needs to mirror the backend's RAM-aware defaults (e.g. dbcache)
+export async function getSystemInfo(): Promise<{totalRamBytes: number}> {
+	return {totalRamBytes: os.totalmem()}
+}
+
 // Update settings.json, umbrel-bitcoin.conf + bitcoin.conf, and restarts bitcoind
 export async function updateSettings(patch: Partial<SettingsSchema>): Promise<SettingsSchema> {
 	const current = await getSettings()
@@ -382,7 +388,7 @@ export async function updateSettings(patch: Partial<SettingsSchema>): Promise<Se
 
 	// Merge defaults for resolved version → current → patch, then validate via dynamic schema
 	const mergedWithDefaults = {
-		...(DefaultValuesForVersion(resolvedVersion) as Record<string, unknown>),
+		...(DefaultValuesForVersion(resolvedVersion, {totalRamBytes: os.totalmem()}) as Record<string, unknown>),
 		...(current as Record<string, unknown>),
 		...(patch as Record<string, unknown>),
 	}
@@ -417,7 +423,7 @@ export async function restoreDefaults(): Promise<SettingsSchema> {
 	const selectedVersion = ((current as {version?: SelectedVersion} | undefined)?.version ?? LATEST) as SelectedVersion
 	const resolvedVersion = resolveVersion(selectedVersion)
 	const defaults = {
-		...(DefaultValuesForVersion(resolvedVersion) as Record<string, unknown>),
+		...(DefaultValuesForVersion(resolvedVersion, {totalRamBytes: os.totalmem()}) as Record<string, unknown>),
 		version: selectedVersion,
 	} as SettingsSchema
 

--- a/apps/backend/src/modules/config/migration.ts
+++ b/apps/backend/src/modules/config/migration.ts
@@ -1,5 +1,6 @@
 // This module is responsible for migrating the JSON config from the previous app (umbel-config.json) to this app's equivalent settings.json
 // It will run on first boot after the update and coerce the values to the new schema if needed.
+import os from 'node:os'
 import path from 'node:path'
 import fse from 'fs-extra'
 import {ZodError} from 'zod'
@@ -133,7 +134,7 @@ export async function migrateLegacyConfig(): Promise<SettingsSchema | undefined>
 
 	try {
 		const latestVersion = resolveVersion(LATEST)
-		const defaultValues = DefaultValuesForVersion(latestVersion)
+		const defaultValues = DefaultValuesForVersion(latestVersion, {totalRamBytes: os.totalmem()})
 		// Merge defaults for latest Bitcoin Core version with coerced legacy values and validate against the
 		// versioned schema to produce a clean, current settings.json
 		const validated = schemaForVersion(LATEST).parse({

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -53,6 +53,7 @@ export default fp(async (app: FastifyInstance) => {
 	const configBase = `${BASE}/config`
 
 	app.get(`${configBase}/settings`, config.getSettings)
+	app.get(`${configBase}/system-info`, config.getSystemInfo)
 
 	app.patch(`${configBase}/settings`, async (req) => {
 		// Validation is handled in config.updateSettings(). Zod errors become 400 via the global handler.

--- a/apps/ui/src/hooks/useSettings.ts
+++ b/apps/ui/src/hooks/useSettings.ts
@@ -3,6 +3,16 @@ import {toast} from 'sonner'
 import {api} from '@/lib/api'
 import type {SettingsSchema} from '#settings'
 
+// System info used to mirror the backend's RAM-aware defaults (e.g. dbcache).
+// Total RAM never changes while the app is open, so cache it forever.
+export function useSystemInfo() {
+	return useQuery({
+		queryKey: ['config', 'system-info'],
+		queryFn: () => api<{totalRamBytes: number}>('/config/system-info'),
+		staleTime: Infinity,
+	})
+}
+
 // TODO: set actual cache times. We don't expect settings to change until the user updates them.
 export function useSettings() {
 	return useQuery({

--- a/apps/ui/src/pages/settings/index.tsx
+++ b/apps/ui/src/pages/settings/index.tsx
@@ -49,7 +49,7 @@ import {
 	type SelectedVersion,
 } from '#settings'
 
-import {useSettings, useUpdateSettings, useRestoreDefaults} from '@/hooks/useSettings'
+import {useSettings, useSystemInfo, useUpdateSettings, useRestoreDefaults} from '@/hooks/useSettings'
 import {useBitcoindExitInfo} from '@/hooks/useBitcoindExitInfo'
 import IncompatibleSettingsAlert from './IncompatibleSettingsAlert.js'
 
@@ -64,14 +64,15 @@ function updateFormWhenVersionChanges(
 	form: ReturnType<typeof useForm>,
 	previousKeys: Set<string>,
 	selectedVersion: SelectedVersion,
+	totalRamBytes?: number,
 ) {
 	// Derive the settings metadata for the target Core version
 	const targetVersion = resolveVersion(selectedVersion)
-	const targetMetadata = settingsMetadataForVersion(targetVersion)
+	const targetMetadata = settingsMetadataForVersion(targetVersion, {totalRamBytes})
 
 	// Derive defaults for the target version and set them ONLY for settings that did not exist in the previous version
 	// e.g., if prev version was v30.0 and user switches to v29.2 there will be a new setting called `maxorphantx` that needs to be set to the default value for v29.2
-	const defaults = DefaultValuesForVersion(targetVersion) as Record<string, unknown>
+	const defaults = DefaultValuesForVersion(targetVersion, {totalRamBytes}) as Record<string, unknown>
 	for (const key of Object.keys(targetMetadata)) {
 		const isNewKey = !previousKeys.has(key)
 		const currentValue = form.getValues(key as any)
@@ -165,6 +166,8 @@ function FieldRenderer({
 }) {
 	const option = settingsMetadata[name] as Option
 	const disabled = useInputsDisabled()
+	// Total system RAM, used to seed RAM-aware defaults (e.g. dbcache) on version switches
+	const {data: systemInfo} = useSystemInfo()
 
 	// Number fields (e.g., dbcache)
 	if (option.kind === 'number') {
@@ -359,7 +362,7 @@ function FieldRenderer({
 									// and revalidate with the new schema for that version
 									if (name === 'version') {
 										const previousKeys = new Set(Object.keys(settingsMetadata))
-										updateFormWhenVersionChanges(form, previousKeys, v as SelectedVersion)
+										updateFormWhenVersionChanges(form, previousKeys, v as SelectedVersion, systemInfo?.totalRamBytes)
 									}
 								}}
 								disabled={disabled}
@@ -403,6 +406,8 @@ export default function SettingsCard() {
 
 	// Form data state
 	const {data: initialSettings, isLoading} = useSettings()
+	// Total system RAM, used to compute RAM-aware defaults (e.g. dbcache)
+	const {data: systemInfo} = useSystemInfo()
 	const updateSettings = useUpdateSettings()
 	const restoreDefaults = useRestoreDefaults()
 	// Save dialog controlled state to avoid any double-open edge cases
@@ -442,7 +447,10 @@ export default function SettingsCard() {
 	// 2) Map the selection to a specific Core version (e.g., 'latest' → 'v30.0')
 	const targetVersion = resolveVersion(selectedVersion as SelectedVersion)
 	// 3) Materialize version-aware metadata used to render the fields and constraints
-	const settingsMetadata = useMemo(() => settingsMetadataForVersion(targetVersion), [targetVersion])
+	const settingsMetadata = useMemo(
+		() => settingsMetadataForVersion(targetVersion, {totalRamBytes: systemInfo?.totalRamBytes}),
+		[targetVersion, systemInfo?.totalRamBytes],
+	)
 
 	// Clear search if navigated here with clearSearch parameter (e.g., from "View logs" button in bitcoind crash toast)
 	useEffect(() => {

--- a/libs/settings/settings.meta.ts
+++ b/libs/settings/settings.meta.ts
@@ -85,6 +85,21 @@ export type VersionedOption = Option & {
 	versionOverrides?: Partial<Record<BitcoinCoreVersion, VersionOverrides>>
 }
 
+// RAM-aware default for -dbcache, mirroring Bitcoin Core v31.0+ (bitcoin/bitcoin#34692):
+// 1024 MiB on systems with at least 4 GiB of detected RAM, 450 MiB otherwise.
+// We apply the same rule regardless of the selected Core version so that older versions
+// (whose built-in default is a flat 450 MiB) benefit as well. An undersized cache is
+// continuously filled and emptied at steady state, causing sustained write amplification
+// on the underlying disk (the full UTXO working set is repeatedly rewritten into LevelDB).
+export const DBCACHE_BASE_DEFAULT_MIB = 450
+export const DBCACHE_HIGH_DEFAULT_MIB = 1024
+export const DBCACHE_HIGH_DEFAULT_MIN_RAM_BYTES = 4096 * 1024 * 1024
+
+export function defaultDbcacheMiB(totalRamBytes?: number): number {
+	if (totalRamBytes && totalRamBytes >= DBCACHE_HIGH_DEFAULT_MIN_RAM_BYTES) return DBCACHE_HIGH_DEFAULT_MIB
+	return DBCACHE_BASE_DEFAULT_MIB
+}
+
 // NOTE: this is the single source of truth for the settings metadata. Everything is derived from this object (versioned metadata, versioned schema, default values, UI fields, etc).
 // TypeScript infers the type of the object literals below based on the `kind` property.
 export const settingsMetadata = {
@@ -297,13 +312,16 @@ export const settingsMetadata = {
 		label: 'Cache Size',
 		bitcoinLabel: 'dbcache',
 		description:
-			'Choose the size of the UTXO set to store in RAM. A larger cache can speed up the initial synchronization of your Bitcoin node, but after the initial sync is complete, a larger cache value does not significantly improve performance and may use more RAM than needed.',
+			'Choose the size of the UTXO cache to keep in RAM. A larger cache speeds up the initial synchronization of your Bitcoin node and reduces disk activity afterwards: whenever the cache fills up it is emptied to disk, so an undersized cache causes the UTXO set to be rewritten over and over. The default matches Bitcoin Core: 1024 MiB on systems with at least 4 GiB of RAM, 450 MiB otherwise.',
 		min: 4,
 		// We don't set the max here because bitcoind will just automatically cap at 16_384 without erroring
 		// and this max value has traditionally increased over time with newer releases
 		// max: 16_384,
 		step: 1,
-		default: 450,
+		// The actual default is RAM-aware and applied in settingsMetadataForVersion() (see defaultDbcacheMiB).
+		// This static value is the fallback when the total system RAM is unknown (e.g. during the first
+		// browser render, before the UI has fetched it from the backend).
+		default: DBCACHE_BASE_DEFAULT_MIB,
 		unit: 'MiB',
 	},
 
@@ -568,7 +586,8 @@ export function resolveVersion(desired: SelectedVersion): BitcoinCoreVersion {
 }
 
 // Creates the version‑specific metadata for a given Bitcoin Core version:
-export function settingsMetadataForVersion(version: BitcoinCoreVersion) {
+// `options.totalRamBytes` (when known) is used to compute RAM-aware defaults (currently just dbcache).
+export function settingsMetadataForVersion(version: BitcoinCoreVersion, options?: {totalRamBytes?: number}) {
 	const metadata: Record<string, Option> = {}
 	const versionIdx = AVAILABLE_BITCOIN_CORE_VERSIONS.indexOf(version)
 
@@ -592,12 +611,18 @@ export function settingsMetadataForVersion(version: BitcoinCoreVersion) {
 		metadata[key] = merged as unknown as Option
 	}
 
+	// Apply the RAM-aware dbcache default when the total system RAM is known
+	if (metadata['dbcache']) {
+		metadata['dbcache'] = {...metadata['dbcache'], default: defaultDbcacheMiB(options?.totalRamBytes)} as Option
+	}
+
 	return metadata
 }
 
 // Compute default form values for a given Bitcoin Core version.
-export function DefaultValuesForVersion(version: BitcoinCoreVersion) {
-	const metadata = settingsMetadataForVersion(version)
+// `options.totalRamBytes` (when known) is used to compute RAM-aware defaults (currently just dbcache).
+export function DefaultValuesForVersion(version: BitcoinCoreVersion, options?: {totalRamBytes?: number}) {
+	const metadata = settingsMetadataForVersion(version, options)
 	const defaults = {} as Record<string, unknown>
 	for (const key in metadata) defaults[key] = (metadata as Record<string, {default: unknown}>)[key].default
 	return defaults


### PR DESCRIPTION
## Motivation

Bitcoin Core v31.0 raised its default `-dbcache` from 450 MiB to 1024 MiB on systems with at least 4 GiB of detected RAM (bitcoin/bitcoin#34692). Because this app always writes an explicit `dbcache` value into `umbrel-bitcoin.conf`, it currently overrides that improvement back down to 450 MiB on every install - including Umbrel Home and other devices with 8-32 GiB of RAM.

This is not just a lost IBD speedup. An undersized UTXO cache is continuously filled and emptied at steady state: every eviction cycle rewrites a large part of the UTXO set into LevelDB, which causes compaction churn and sustained write amplification on the node's SSD. I recently diagnosed a stock node from this app (dbcache=450, txindex and blockfilterindex on, fully synced and idle at tip on a 16 GiB VM) that was averaging roughly 2 MB/s of disk writes - about 170 GB/day - measured over three weeks of container uptime. Raising dbcache stopped the write churn. Given how many of these nodes run 24/7 on consumer SSDs, the fleet-wide write savings are significant.

Related: bitcoin/bitcoin#35865 adds a warning to Core when this thrashing pattern is detected at runtime.

## What this does

Mirrors Core's exact rule in the app: default `dbcache` is **1024 MiB when the system has at least 4 GiB of RAM, 450 MiB otherwise**. The rule is applied for all selectable Core versions - older versions accept dbcache=1024 just as well and benefit equally.

- `libs/settings`: new `defaultDbcacheMiB(totalRamBytes?)` + optional `totalRamBytes` option on `settingsMetadataForVersion()` / `DefaultValuesForVersion()`; the dbcache description no longer claims a larger cache has no benefit after IBD (the opposite is true for disk activity)
- `backend`: passes `os.totalmem()` wherever defaults are computed (settings load, PATCH merge, restore-defaults, legacy migration); new `GET /api/config/system-info` endpoint exposing `totalRamBytes`
- `ui`: new `useSystemInfo()` hook so the displayed "default: X MiB" caption and version-switch seeding match what the backend actually applies

## What this deliberately does not do

Existing installs are not migrated: `settings.json` already contains a persisted `dbcache` value, and persisted values always win over defaults. Only fresh installs and users who hit "restore defaults" pick up the new value. If you want existing untouched-450 installs to be bumped too, I am happy to add that in a follow-up, but it felt like a decision for the maintainers since a persisted 450 is indistinguishable from a deliberate user choice.

## Testing

- `defaultDbcacheMiB()`: no RAM info -> 450, 2 GiB -> 450, 4 GiB -> 1024, 16 GiB -> 1024
- `DefaultValuesForVersion(v, {totalRamBytes})` and `settingsMetadataForVersion(v, {totalRamBytes})` return the RAM-aware default; without the option they fall back to 450 (browser-safe)
- `npm run typecheck` and `npm run lint` report exactly the same results as master (no new issues)
- `npx prettier --check` passes on all changed files
